### PR TITLE
Fix something?

### DIFF
--- a/core.cmake
+++ b/core.cmake
@@ -725,7 +725,7 @@ function(CGET_FIND_DEPENDENCY)
 	elseif(ARGS_LIBRARY)
 		find_library(${ARGN})
 	else()
-        find_package(${ARGN})
+        find_package(${ARGS_FINDNAME})
 	endif()
 endfunction()
 


### PR DESCRIPTION
This couldn't find Poco for me, but it seems like it was because it was calling find_package() with all the args:

"Poco;COMPONENTS;Util;Foundation" 

When it should have just been 

"Poco"